### PR TITLE
C++17 build fix : Renamed byte typedef to u8 to avoid ambiguity with …

### DIFF
--- a/common.h
+++ b/common.h
@@ -81,7 +81,7 @@ extern const char* EMPTY_BOARD;
 
 #define NO_EP_SQUARE 64
 typedef unsigned long long u64;
-typedef unsigned char byte;
+typedef unsigned char u8;
 typedef int boolean;
 typedef struct {
   char b[64];

--- a/hash.h
+++ b/hash.h
@@ -29,10 +29,10 @@ enum { H_LE, H_EQ, H_GE };
 
 typedef struct {
   u64 hash_value;
-  byte depth;
+  u8 depth;
   int value;
-  byte type;
-  byte best_move;
+  u8 type;
+  u8 best_move;
 } t_hash_entry;
 
 extern t_hash_entry* hash_data;

--- a/pns.h
+++ b/pns.h
@@ -49,7 +49,7 @@ typedef struct _t_pns_node_ {
   tmove mv;                      // How did we reach this node from its parent
   struct _t_pns_node_* parent;
   struct _t_pns_node_** child;   // The links of this node
-  byte num_children;             // = sizeof(child)
+  u8 num_children;             // = sizeof(child)
   int proof, disproof;           // From the side to move's point of view
   double ratio;
   int size;                      // # of nodes in this tree, including self


### PR DESCRIPTION
…std::byte.